### PR TITLE
Allow setting SSL Protocol version, change default from SSLv2 to SSLv3

### DIFF
--- a/fakemtpd/connection.py
+++ b/fakemtpd/connection.py
@@ -51,7 +51,8 @@ class Connection(Signalable):
         assert self.state == CONNECTED
         log.debug("starting TLS session")
         self.sock = ssl.wrap_socket(self.sock, server_side=True,
-                do_handshake_on_connect=False, **ssl_options)
+                do_handshake_on_connect=False,
+                **ssl_options)
         self.io_loop.remove_handler(self.sock.fileno())
         self.stream = tornado.iostream.SSLIOStream(self.sock, io_loop = self.io_loop)
         self.stream.set_close_callback(self.close)

--- a/fakemtpd/smtpsession.py
+++ b/fakemtpd/smtpsession.py
@@ -153,7 +153,7 @@ class SMTPSession(object):
         return False
 
     def _starttls(self):
-        self.conn.starttls(keyfile=self.config.tls_key, certfile=self.config.tls_cert)
+        self.conn.starttls(keyfile=self.config.tls_key, certfile=self.config.tls_cert, ssl_version=self.config.ssl_version)
         self._encrypted = True
 
     def _state_mail_from(self, data):


### PR DESCRIPTION
Unfortunately, allowing both SSLv3 and TLSv1 requires Python 2.7 or higher, so I'm not doing that right now.
